### PR TITLE
Removes deprecated `Statefile`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ Expects an array of Hashes with the following keys:
 * `tag`       (optional)
   - a tag to attach to content from the file
   - Default: basename of filename with periods replaced with dashes (e.g. `/d/f.log` -> `f-log`)
-* `statefile` (optional)
-  - an absolute path to the rsyslog statefile
-  - Default: the filename path with `.rsyslog_state` appended (e.g. `/d/f.log` -> `/d/f.log.rsyslog_state`)
 * `severity`  (optional)
   - the rsyslog severity for the contents of the file
   - Default: the severity will be omitted from the config if it isn't set. Rsyslog will default it to `Info`
@@ -56,7 +53,7 @@ Example:
   node.set.loggly.log_files = [
     { 'filename' => '/string/key.file.ext' },
     { filename: '/just/a/file.log' },
-    { filename: '/every/thing.txt', tag: 'all the options', statefile: '/tmp/state', severity: 'Warning' }
+    { filename: '/every/thing.txt', tag: 'all the options', severity: 'Warning' }
   ]
 ```
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,9 @@ source_url       'https://github.com/spartansystems/spartan_loggly_rsyslog-cookb
 issues_url       'https://github.com/spartansystems/spartan_loggly_rsyslog-cookbook/issues'
 description      'Configures rsyslog to send logs to Loggly'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.0'
+version          '4.0.0'
 
 supports 'ubuntu', '>= 14.04'
 
-depends 'apt', '~> 3.0.0'
+depends 'apt'
 depends 'rsyslog', '~> 4.0.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,6 @@ log_files = node.loggly.log_files.reject { |f| !f.is_a?(Hash) || !f.key?('filena
 files = log_files.map do |f|
   f = f.to_h
   f['tag'] = File.basename(f['filename']).tr('.', '-') unless f.key?('tag')
-  f['statefile'] = "#{f['filename']}.rsyslog_state" unless f.key?('statefile')
   f
 end
 

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -162,7 +162,7 @@ describe 'spartan_loggly_rsyslog::default' do
       [
         { 'filename' => '/string/key.file.ext' },
         { filename: '/just/a/file.log' },
-        { filename: '/every/thing.txt', tag: 'all the options', statefile: '/tmp/state', severity: 'Warning' }
+        { filename: '/every/thing.txt', tag: 'all the options', severity: 'Warning' }
       ]
     end
     let(:chef_run) do
@@ -183,17 +183,14 @@ describe 'spartan_loggly_rsyslog::default' do
         input(type="imfile"
               File="/string/key.file.ext"
               Tag="key-file-ext"
-              Statefile="/string/key.file.ext.rsyslog_state"
           )
         input(type="imfile"
               File="/just/a/file.log"
               Tag="file-log"
-              Statefile="/just/a/file.log.rsyslog_state"
           )
         input(type="imfile"
               File="/every/thing.txt"
               Tag="all the options"
-              Statefile="/tmp/state"
               Severity="Warning"
           )
       EOS

--- a/templates/default/files.conf.erb
+++ b/templates/default/files.conf.erb
@@ -6,7 +6,6 @@ module(load="imfile" PollingInterval="<%= node.loggly.rsyslog.input_file_poll_in
 input(type="imfile"
       File="<%= logfile['filename'] %>"
       Tag="<%= logfile['tag'] %>"
-      Statefile="<%= logfile['statefile'] %>"
   <%- if logfile.key?('severity') -%>
       Severity="<%= logfile['severity'] %>"
   <%- end %>

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -34,7 +34,6 @@ describe file('/etc/rsyslog.d/99-files.conf') do
     input(type="imfile"
           File="/tmp/test.log"
           Tag="test-log"
-          Statefile="/tmp/test.log.rsyslog_state"
       )
   EOS
 


### PR DESCRIPTION
`Statefile` has been deprecated with Rsyslog 8.0.
